### PR TITLE
Introduced alternate column scanner constructor for injecting the header.

### DIFF
--- a/csv/column_scanner_test.go
+++ b/csv/column_scanner_test.go
@@ -69,6 +69,20 @@ func (this *ColumnScannerFixture) TestColumnNotFound_Panic() {
 	this.So(func() { this.scanner.Column("nope") }, should.Panic)
 }
 
+func (this *ColumnScannerFixture) TestReadColumnsFromInjectedHeader() {
+	this.scanner = NewColumnScannerWithoutHeader(
+		reader(csvCanonWithoutHeader),
+		[]string{"first_name", "last_name", "username"},
+	)
+	this.ScanAllUsers()
+
+	this.So(this.scanner.Error(), should.BeNil)
+	this.So(this.users, should.Resemble, []User{
+		{FirstName: "Rob", LastName: "Pike", Username: "rob"},
+		{FirstName: "Ken", LastName: "Thompson", Username: "ken"},
+		{FirstName: "Robert", LastName: "Griesemer", Username: "gri"},
+	})
+}
 
 type User struct {
 	FirstName string
@@ -76,7 +90,7 @@ type User struct {
 	Username  string
 }
 
-type ErrorReader struct {}
+type ErrorReader struct{}
 
 func (this *ErrorReader) Read(p []byte) (n int, err error) {
 	return 0, errors.New("ERROR")

--- a/csv/scanner_test.go
+++ b/csv/scanner_test.go
@@ -130,6 +130,7 @@ var ( // https://golang.org/pkg/encoding/csv/#example_Reader
 		{3, []string{"Ken", "Thompson", "ken"}, nil},
 		{4, []string{"Robert", "Griesemer", "gri"}, nil},
 	}
+	csvCanonWithoutHeader = csvCanon[1:]
 )
 
 type Record struct {


### PR DESCRIPTION
Resolves #3

@sgraham785 - I think these changes would allow you to inject your own header without losing the first record to the `NewColumnScanner` constructor function. What do you think?